### PR TITLE
Replaced deprecated `fa-pulse` with `fa-spin-pulse`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Segmented spinners such as the "8 dot spinner" are intended to be animated in a 
 
 ![please-fix-your-spinner](./please-fix-your-spinner.gif)
 
-> **Using FontAwesome?** Great! All you have to do is change the class on your spinner from `fa-spin` to `fa-pulse`!
+> **Using FontAwesome?** Great! All you have to do is change the class on your spinner from `fa-spin` or deprecated `fa-pulse` to `fa-spin-pulse`!

--- a/src/ProTip.tsx
+++ b/src/ProTip.tsx
@@ -39,7 +39,11 @@ export const ProTip = () => (
   <ProTipIcon><InfoIcon fill="#666" /></ProTipIcon>
   <ProTipContent>
     <ProTipTitle>Using FontAwesome?</ProTipTitle>
-    <ProTipDescription>Great! All you have to do is change the class on your spinner from <Code>fa-spin</Code> to <Code>fa-pulse</Code>!</ProTipDescription>
+    <ProTipDescription>
+      Great! All you have to do is change the class on your spinner from
+      <Code>fa-spin</Code> or deprecated <Code>fa-pulse</Code> to
+      <Code>fa-spin-pulse</Code>!
+    </ProTipDescription>
   </ProTipContent>
 </ProTipWrapper>
 );


### PR DESCRIPTION
From [Font Awesome spin-utilities docs](https://docs.fontawesome.com/web/style/animate#spin-utilities):

![Screenshot From 2025-06-14 14-48-01](https://github.com/user-attachments/assets/eb05a9da-53b9-4b06-bf92-54063b5079a5)
